### PR TITLE
Use GitHub's raw url directly in webhook body

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -26,7 +26,7 @@ class SendWebhookJob
 
   def webhook_body(pull_request_number, pull_request_head)
     {
-      countries_json_url: "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{pull_request_head}/countries.json",
+      countries_json_url: "https://github.com/everypolitician/everypolitician-data/raw/#{pull_request_head}/countries.json",
       pull_request_url: "https://api.github.com/repos/everypolitician/everypolitician-data/pulls/#{pull_request_number}"
     }
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -79,7 +79,7 @@ describe 'App' do
         name: 'Test',
         webhook_url: 'http://example.com'
       )
-      @body = '{"countries_json_url":"https://cdn.rawgit.com/everypolitician/everypolitician-data/abc123/countries.json","pull_request_url":"https://api.github.com/repos/everypolitician/everypolitician-data/pulls/42"}'
+      @body = '{"countries_json_url":"https://github.com/everypolitician/everypolitician-data/raw/abc123/countries.json","pull_request_url":"https://api.github.com/repos/everypolitician/everypolitician-data/pulls/42"}'
     end
 
     it 'dispatches webhook' do


### PR DESCRIPTION
RawGit has sadly been down a couple of times recently. To avoid
potential problems with it this switches to using a regular GitHub raw
url in the payload.