### PR TITLE
include list of affected legislatures in webhook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: ba9bf4dc5d16005811811db065a202c945f95bc4
+  revision: 1ab5d5ba15ff42cb1af01ba7528b948becfb1544
   specs:
     everypolitician (0.7.0)
       everypolitician-popolo

--- a/app.rb
+++ b/app.rb
@@ -55,6 +55,10 @@ helpers do
     pr_files = Octokit.pull_request_files(payload['repository']['full_name'], payload['number'])
     pr_files.map { |f| legislature_for_file(f['filename']) }.compact.uniq
   end
+
+  def legislatures_for_sources(sources)
+    sources.map { |s| EveryPolitician::Legislature.from_sources_dir(s.to_s) }.map { |l| { :country_slug => l.country.slug, :legislature_slug  => l.slug } }
+  end
 end
 
 use OmniAuth::Builder do
@@ -100,7 +104,7 @@ post '/' do
       pull_request_action,
       payload['number'],
       payload['pull_request']['head']['sha'],
-      countries
+      legislatures_for_sources(countries)
     )
   end
   "Dispatched #{applications.count} webhooks"

--- a/app.rb
+++ b/app.rb
@@ -87,8 +87,9 @@ post '/' do
   else
     halt 400, "Unknown action: #{payload['action']}"
   end
+  countries = legislatures_in_pr(payload)
   applications = Application
-    .where(:legislature => legislatures_in_pr(payload))
+    .where(:legislature => countries)
     .or(:legislature => nil)
     .or(:legislature => '')
     .exclude(webhook_url: '')
@@ -98,7 +99,8 @@ post '/' do
       application.id,
       pull_request_action,
       payload['number'],
-      payload['pull_request']['head']['sha']
+      payload['pull_request']['head']['sha'],
+      countries
     )
   end
   "Dispatched #{applications.count} webhooks"

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -24,11 +24,11 @@ class SendWebhookJob
     end
   end
 
-  def webhook_body(pull_request_number, pull_request_head, pull_request_countries)
+  def webhook_body(pull_request_number, pull_request_head, legislatures_affected)
     {
       countries_json_url: "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{pull_request_head}/countries.json",
       pull_request_url: "https://api.github.com/repos/everypolitician/everypolitician-data/pulls/#{pull_request_number}",
-      legislatures_affected: pull_request_countries
+      legislatures_affected: legislatures_affected
     }
   end
 end


### PR DESCRIPTION
The webhook JSON now includes an legislatures_affected key which is an
array with a list of $country/$legislature strings for all the
legislatures affected by the change

Fixes everypolitician/everypolitician#452