### PR TITLE
Handle GitHub accounts with no name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,8 @@
 # Represents an authenticated user
 class User < Sequel::Model
   one_to_many :applications
+
+  def to_s
+    name || email
+  end
 end

--- a/db/migrations/014_make_user_name_nullable.rb
+++ b/db/migrations/014_make_user_name_nullable.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:users) do
+      set_column_allow_null :name
+    end
+  end
+end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -136,6 +136,7 @@ describe 'App' do
       assert last_response.body.include?(
         'You have successfully logged in with GitHub'
       )
+      assert last_response.body.include?('Logged in as Bob Test')
     end
 
     it 'uses existing user if one exists' do
@@ -167,6 +168,8 @@ describe 'App' do
         get '/auth/github'
         follow_redirect!
       end
+      2.times { follow_redirect! }
+      assert last_response.body.include?('Logged in as bob@example.org')
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -136,6 +136,23 @@ describe 'App' do
       end
       assert_equal 'http://example.org/auth/github/callback', last_request.url
     end
+
+    it "works if a user doesn't have a name set on GitHub" do
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+        provider: 'github',
+        uid: '123545',
+        info: {
+          email: 'bob@example.org'
+        },
+        credentials: {
+          token: 'abc123'
+        }
+      )
+      assert_difference 'User.count', 1 do
+        get '/auth/github'
+        follow_redirect!
+      end
+    end
   end
 
   describe 'logout' do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -26,6 +26,7 @@ describe 'App' do
       :body => '[{"slug":"example","legislatures":[{"slug":"example","sources_directory":"data/example/example/sources"}]}]',
       :headers => {'Content-Type'=>'application/json'}
     )
+    OmniAuth.config.mock_auth[:github] = nil
   end
 
   it 'has a homepage' do
@@ -108,6 +109,20 @@ describe 'App' do
   end
 
   describe 'login' do
+    before do
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+        provider: 'github',
+        uid: '123545',
+        info: {
+          name: 'Bob Test',
+          email: 'bob@example.org'
+        },
+        credentials: {
+          token: 'abc123'
+        }
+      )
+    end
+
     it 'creates a new user if none found' do
       assert_difference 'User.count', 1 do
         get '/auth/github'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,17 @@ class Minitest::Spec
   end
 
   def login!
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+      provider: 'github',
+      uid: '123545',
+      info: {
+        name: 'Bob Test',
+        email: 'bob@example.org'
+      },
+      credentials: {
+        token: 'abc123'
+      }
+    )
     get '/auth/github'
     3.times { follow_redirect! }
   end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,13 +1,1 @@
 OmniAuth.config.test_mode = true
-
-OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
-  provider: 'github',
-  uid: '123545',
-  info: {
-    name: 'Bob Test',
-    email: 'bob@example.org'
-  },
-  credentials: {
-    token: 'abc123'
-  }
-)

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe User do
+  describe '#to_s' do
+    it 'returns the name if the user has one' do
+      assert_equal 'Bob', User.new(name: 'Bob').to_s
+    end
+
+    it 'returns the email if user has no name' do
+      assert_equal 'bob@example.org', User.new(email: 'bob@example.org').to_s
+    end
+  end
+end

--- a/views/user_bar.erb
+++ b/views/user_bar.erb
@@ -23,7 +23,7 @@
         </li>
       </ul>
       <% if current_user %>
-        <p class="navbar-text navbar-right">Logged in as <%= current_user.name %>
+        <p class="navbar-text navbar-right">Logged in as <%= current_user %>
       <% end %>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->


### PR DESCRIPTION
This removes the requirement for users to have a name set on their GitHub account. As part of this change I've also refactored the omniauth bits in the tests as they were causing failures when the tests were run in a certain order.

Fixes https://github.com/everypolitician/webhook-manager/issues/68

![screen shot 2016-07-28 at 11 21 17](https://cloud.githubusercontent.com/assets/22996/17209555/72bda394-54b5-11e6-82ed-201a489f9471.png)
