### PR TITLE
Update Rollbar gem to 2.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'everypoliticianbot', github: 'everypolitician/everypoliticianbot'
 gem 'sinatra-github_webhooks'
 
 # Rollbar integration (oj is recommended)
-gem 'rollbar', '~> 2.4.0'
+gem 'rollbar', '~> 2.13'
 gem 'oj', '~> 2.12.14'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     jwt (1.5.0)
     method_source (0.8.2)
     minitest (5.7.0)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     oauth2 (1.0.0)
@@ -91,7 +91,7 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    rollbar (2.4.0)
+    rollbar (2.13.0)
       multi_json
     rubocop (0.31.0)
       astrolabe (~> 1.3)
@@ -158,7 +158,7 @@ DEPENDENCIES
   rack-flash3
   rack-test
   rake
-  rollbar (~> 2.4.0)
+  rollbar (~> 2.13)
   rubocop
   sequel
   sidekiq
@@ -169,4 +169,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
This should fix warnings from Rollbar about using an outdated version.