### PR TITLE
Remove broken require in app.rb

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -26,7 +26,6 @@ end
 
 configure :production do
   require 'rollbar/middleware/sinatra'
-  require 'rollbar/sidekiq'
 
   use Rollbar::Middleware::Sinatra
 


### PR DESCRIPTION
This no longer works as the Sidekiq support in Rollbar has been moved
into a plugin [1]. Though I couldn't find it documented anywhere, after
a bit of digging in the code it turns out that all plugins are loaded
automatically [2].

So this line is no longer needed and is, in fact, broken.

[1]: https://rollbar.com/docs/notifier/rollbar-gem/plugins/
[2]: https://github.com/rollbar/rollbar-gem/blob/v2.13.0/lib/rollbar.rb#L195