### PR TITLE
Add bundle-audit checking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rubocop', require: false
 gem 'faraday'
 gem 'pry', require: false
 gem 'activesupport', require: 'active_support'
-gem 'everypolitician', github: 'everypolitician/everypolitician-ruby'
+gem 'everypolitician', github: 'everypolitician/everypolitician-ruby', ref: '1ab5d5b'
 gem 'sinatra-github_webhooks'
 
 # Rollbar integration (oj is recommended)

--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,5 @@ group :test do
   gem 'simplecov', require: false
   gem 'database_cleaner'
   gem 'webmock'
+  gem 'bundler-audit', '~> 0.5'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'faraday'
 gem 'pry', require: false
 gem 'activesupport', require: 'active_support'
 gem 'everypolitician', github: 'everypolitician/everypolitician-ruby'
-gem 'everypoliticianbot', github: 'everypolitician/everypoliticianbot'
 gem 'sinatra-github_webhooks'
 
 # Rollbar integration (oj is recommended)

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.2.3'
 
 gem 'sinatra'
 gem 'dotenv'
-gem 'sidekiq'
+gem 'sidekiq', '~> 4.2'
 gem 'octokit'
 gem 'puma'
 gem 'sequel'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 ruby '2.2.3'
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 gem 'sinatra'
 gem 'dotenv'
 gem 'sidekiq', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,6 @@ GIT
     everypolitician (0.7.0)
       everypolitician-popolo
 
-GIT
-  remote: git://github.com/everypolitician/everypoliticianbot.git
-  revision: dbf23a5a419ce9e58de678c020c1ae9ec1fd3796
-  specs:
-    everypoliticianbot (0.1.0)
-      git (~> 1.2)
-      octokit (~> 4.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -41,7 +33,6 @@ GEM
     everypolitician-popolo (0.3.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    git (1.2.9.1)
     hashie (3.4.2)
     i18n (0.7.0)
     json (1.8.3)
@@ -144,7 +135,6 @@ DEPENDENCIES
   database_cleaner
   dotenv
   everypolitician!
-  everypoliticianbot!
   faraday
   minitest
   octokit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/everypolitician/everypolitician-ruby.git
+  remote: https://github.com/everypolitician/everypolitician-ruby.git
   revision: 1ab5d5ba15ff42cb1af01ba7528b948becfb1544
   ref: 1ab5d5b
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
     bacon (1.2.0)
+    bundler-audit (0.5.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
@@ -128,6 +131,7 @@ GEM
       sequel (>= 3.2.0)
       sinatra (>= 0.9.4)
     slop (3.6.0)
+    thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
     timers (4.0.1)
@@ -143,6 +147,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  bundler-audit (~> 0.5)
   database_cleaner
   dotenv
   everypolitician!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,9 +30,8 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
     coderay (1.1.0)
+    concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -44,9 +43,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     git (1.2.9.1)
     hashie (3.4.2)
-    hitimes (1.2.2)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.3)
     jwt (1.5.0)
     method_source (0.8.2)
     minitest (5.7.0)
@@ -91,9 +89,7 @@ GEM
       rack (>= 1.0)
     rainbow (2.0.0)
     rake (10.4.2)
-    redis (3.2.1)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
+    redis (3.3.1)
     rollbar (2.13.0)
       multi_json
     rubocop (0.31.0)
@@ -108,12 +104,11 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     sequel (4.22.0)
-    sidekiq (3.3.4)
-      celluloid (>= 0.16.0)
-      connection_pool (>= 2.1.1)
-      json
-      redis (>= 3.0.6)
-      redis-namespace (>= 1.3.1)
+    sidekiq (4.2.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (~> 1.5)
+      redis (~> 3.2, >= 3.2.1)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -134,8 +129,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
-    timers (4.0.1)
-      hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     webmock (1.21.0)
@@ -166,7 +159,7 @@ DEPENDENCIES
   rollbar (~> 2.13)
   rubocop
   sequel
-  sidekiq
+  sidekiq (~> 4.2)
   simplecov
   sinatra
   sinatra-github_webhooks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       slop (~> 3.4)
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
-    rack (1.6.1)
+    rack (1.6.4)
     rack-flash3 (1.0.5)
       rack
     rack-github_webhooks (0.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
   revision: 1ab5d5ba15ff42cb1af01ba7528b948becfb1544
+  ref: 1ab5d5b
   specs:
     everypolitician (0.7.0)
       everypolitician-popolo
@@ -30,7 +31,7 @@ GEM
     database_cleaner (1.4.1)
     docile (1.1.5)
     dotenv (2.0.1)
-    everypolitician-popolo (0.3.1)
+    everypolitician-popolo (0.6.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     hashie (3.4.2)

--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,7 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: :test
+require 'bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: %w(test bundle:audit)


### PR DESCRIPTION
Use bundler-audit (https://github.com/rubysec/bundler-audit) to report if any of the gems we're using have known vulnerabilities.

This is integrated into Travis, with auto-updating of the vulnerabilities file.

Similar change to https://github.com/everypolitician/viewer-sinatra/pull/15176
Part of https://github.com/everypolitician/everypolitician/issues/493